### PR TITLE
Added ESP32 Min Definition

### DIFF
--- a/src/util/inv_mpu.c
+++ b/src/util/inv_mpu.c
@@ -24,6 +24,11 @@
 #include <math.h>
 #include "inv_mpu.h"
 
+#ifdef ESP32
+#define min(a,b) ((a)<(b)?(a):(b))
+#endif
+
+
 /* The following functions must be defined for this platform:
  * i2c_write(unsigned char slave_addr, unsigned char reg_addr,
  *      unsigned char length, unsigned char const *data)

--- a/src/util/inv_mpu.c
+++ b/src/util/inv_mpu.c
@@ -28,6 +28,9 @@
 #define min(a,b) ((a)<(b)?(a):(b))
 #endif
 
+#ifdef ESP8266
+#define min(a,b) ((a)<(b)?(a):(b))
+#endif
 
 /* The following functions must be defined for this platform:
  * i2c_write(unsigned char slave_addr, unsigned char reg_addr,


### PR DESCRIPTION
As far as I can tell the otherwise is otherwise 100% ESP32 Compatible. 

A definition for the min function is all that prevents the library from compiling with ESP32.

I tested the DMP Pedometer sketch just fine using the Heltec Lora ESP32 Modules. 