### PR TITLE
Add word size to integer literals

### DIFF
--- a/src/SparkFunMPU9250-DMP.cpp
+++ b/src/SparkFunMPU9250-DMP.cpp
@@ -615,9 +615,9 @@ float MPU9250_DMP::qToFloat(long number, unsigned char q)
 	unsigned long mask = 0;
 	for (int i=0; i<q; i++)
 	{
-		mask |= (1<<i);
+		mask |= (1L<<i);
 	}
-	return (number >> q) + ((number & mask) / (float) (2<<(q-1)));
+	return (number >> q) + ((number & mask) / (float) (2L<<(q-1)));
 }
 
 void MPU9250_DMP::computeEulerAngles(bool degrees)


### PR DESCRIPTION
The ATMega2560 appears to be treating the integer literals in MPU9250_DMP::qToFloat as int16_t instead of longs. Add `L` modifier to fix that.

This should address https://github.com/sparkfun/SparkFun_MPU-9250-DMP_Arduino_Library/issues/22